### PR TITLE
Fix: v0.2.0 security and code quality fixes

### DIFF
--- a/src/main/java/com/tamerm/blog_app/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/tamerm/blog_app/config/PasswordEncoderConfig.java
@@ -1,0 +1,17 @@
+package com.tamerm.blog_app.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/**
+ * Configuration for password encoding.
+ */
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/tamerm/blog_app/controller/PostController.java
+++ b/src/main/java/com/tamerm/blog_app/controller/PostController.java
@@ -96,16 +96,19 @@ public class PostController {
      * @return the updated post
      */
     @PutMapping("/{id}")
-    @Operation(summary = "Update an existing post", description = "Updates an existing post with the given details")
+    @Operation(summary = "Update an existing post", description = "Updates a post owned by the authenticated user")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Post updated successfully"),
             @ApiResponse(responseCode = "400", description = "Invalid input data"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
             @ApiResponse(responseCode = "404", description = "Post not found")
     })
     public ResponseEntity<PostDTO> updatePost(
             @PathVariable @Parameter(description = "ID of the post to update") Long id,
-            @Valid @RequestBody UpdatePostRequest request) {
-        PostDTO postDTO = postService.updatePost(id, request);
+            @Valid @RequestBody UpdatePostRequest request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        PostDTO postDTO = postService.updatePost(id, request, userDetails);
         return ResponseEntity.ok(postDTO);
     }
 

--- a/src/main/java/com/tamerm/blog_app/controller/PostController.java
+++ b/src/main/java/com/tamerm/blog_app/controller/PostController.java
@@ -42,7 +42,7 @@ public class PostController {
      * @return the created post
      */
     @PostMapping
-    @Operation(summary = "Create a new post", description = "Creates a new post with the given details")
+    @Operation(summary = "Create a new post", description = "Creates a new post for the authenticated user")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Post created successfully"),
             @ApiResponse(responseCode = "400", description = "Invalid input data"),
@@ -50,9 +50,8 @@ public class PostController {
     })
     public ResponseEntity<PostDTO> createPost(
             @Valid @RequestBody CreatePostRequest request,
-            @RequestParam @Parameter(description = "ID of the user creating the post") Long userId,
             @AuthenticationPrincipal UserDetails userDetails) {
-        PostDTO createdPost = postService.createPost(request, userId, userDetails);
+        PostDTO createdPost = postService.createPost(request, userDetails);
         return new ResponseEntity<>(createdPost, HttpStatus.CREATED);
     }
 
@@ -119,17 +118,17 @@ public class PostController {
      * @return a response entity with no content
      */
     @DeleteMapping("/{postId}")
-    @Operation(summary = "Delete a post by ID", description = "Deletes a post by its ID")
+    @Operation(summary = "Delete a post by ID", description = "Deletes a post owned by the authenticated user")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "Post deleted successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "403", description = "Forbidden"),
             @ApiResponse(responseCode = "404", description = "Post not found")
     })
     public ResponseEntity<Void> deletePost(
             @PathVariable @Parameter(description = "ID of the post to delete") Long postId,
-            @RequestParam @Parameter(description = "ID of the user who owns the post") Long userId,
             @AuthenticationPrincipal UserDetails userDetails) {
-        postService.deletePost(postId, userId, userDetails);
+        postService.deletePost(postId, userDetails);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/tamerm/blog_app/security/JWTServiceImpl.java
+++ b/src/main/java/com/tamerm/blog_app/security/JWTServiceImpl.java
@@ -5,12 +5,14 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 /**
@@ -19,7 +21,11 @@ import java.util.Date;
 @Service
 public class JWTServiceImpl implements JWTService {
 
-    private final SecretKey key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    private final SecretKey key;
+
+    public JWTServiceImpl(@Value("${jwt.secret}") String secret) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
 
     @Override
     public String generateToken(User user) {

--- a/src/main/java/com/tamerm/blog_app/security/SecurityConfig.java
+++ b/src/main/java/com/tamerm/blog_app/security/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
                         .requestMatchers("/h2-console/**", "/users/login", "/users/create", "/users/logout").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**", "/swagger-ui.html").permitAll()
                         .requestMatchers(HttpMethod.POST, "/posts/**").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/posts/**").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/posts/**").authenticated()
                         .requestMatchers("/posts/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/tamerm/blog_app/security/SecurityConfig.java
+++ b/src/main/java/com/tamerm/blog_app/security/SecurityConfig.java
@@ -30,8 +30,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/h2-console/**", "/users/login", "/users/create", "/users/logout").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers(HttpMethod.DELETE, "/posts/**").authenticated() // Require authentication for DELETE requests
-                        .requestMatchers("/posts/**").permitAll() // Allow unauthenticated access to other post endpoints
+                        .requestMatchers(HttpMethod.POST, "/posts/**").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/posts/**").authenticated()
+                        .requestMatchers("/posts/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))

--- a/src/main/java/com/tamerm/blog_app/security/SecurityConfig.java
+++ b/src/main/java/com/tamerm/blog_app/security/SecurityConfig.java
@@ -16,10 +16,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final JWTServiceImpl jwtService;
+    private final JWTService jwtService;
     private final UserDetailsService userDetailsService;
 
-    public SecurityConfig(JWTServiceImpl jwtService, UserDetailsService userDetailsService) {
+    public SecurityConfig(JWTService jwtService, UserDetailsService userDetailsService) {
         this.jwtService = jwtService;
         this.userDetailsService = userDetailsService;
     }

--- a/src/main/java/com/tamerm/blog_app/service/PostService.java
+++ b/src/main/java/com/tamerm/blog_app/service/PostService.java
@@ -9,10 +9,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.List;
 
 public interface PostService {
-    PostDTO createPost(CreatePostRequest request, Long userId, UserDetails userDetails);
+    PostDTO createPost(CreatePostRequest request, UserDetails userDetails);
     List<PostSummaryDTO> getAllPosts();
     PostDTO getPostById(Long id);
     PostDTO updatePost(Long id, UpdatePostRequest request);
-    void deletePost(Long postId, Long userId, UserDetails userDetails);
+    void deletePost(Long postId, UserDetails userDetails);
     List<PostSummaryDTO> getPostsByTagName(String tagName);
 }

--- a/src/main/java/com/tamerm/blog_app/service/PostService.java
+++ b/src/main/java/com/tamerm/blog_app/service/PostService.java
@@ -12,7 +12,7 @@ public interface PostService {
     PostDTO createPost(CreatePostRequest request, UserDetails userDetails);
     List<PostSummaryDTO> getAllPosts();
     PostDTO getPostById(Long id);
-    PostDTO updatePost(Long id, UpdatePostRequest request);
+    PostDTO updatePost(Long id, UpdatePostRequest request, UserDetails userDetails);
     void deletePost(Long postId, UserDetails userDetails);
     List<PostSummaryDTO> getPostsByTagName(String tagName);
 }

--- a/src/main/java/com/tamerm/blog_app/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/tamerm/blog_app/service/impl/PostServiceImpl.java
@@ -49,8 +49,9 @@ public class PostServiceImpl implements PostService {
      */
     @Transactional
     @Override
-    public PostDTO createPost(CreatePostRequest request, Long userId, UserDetails userDetails) {
-        log.debug("Creating post for userId: {}", userId);
+    public PostDTO createPost(CreatePostRequest request, UserDetails userDetails) {
+        User user = (User) userDetails;
+        log.debug("Creating post for userId: {}", user.getId());
         if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
             log.error("Post title cannot be empty");
             throw new BadRequestException("Post title cannot be empty");
@@ -63,8 +64,6 @@ public class PostServiceImpl implements PostService {
             post.setTags(tags);
         }
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
         post.setUser(user);
 
         Post savedPost = postRepository.save(post);
@@ -162,12 +161,13 @@ public class PostServiceImpl implements PostService {
      */
     @Transactional
     @Override
-    public void deletePost(Long postId, Long userId, UserDetails userDetails) {
+    public void deletePost(Long postId, UserDetails userDetails) {
+        User user = (User) userDetails;
         log.debug("Deleting post with id: {}", postId);
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new ResourceNotFoundException("Post not found with id " + postId));
 
-        if (!post.getUser().getId().equals(userId)) {
+        if (!post.getUser().getId().equals(user.getId())) {
             log.error("User not authorized to delete this post");
             throw new UnauthorizedException("User not authorized to delete this post");
         }

--- a/src/main/java/com/tamerm/blog_app/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/tamerm/blog_app/service/impl/PostServiceImpl.java
@@ -116,10 +116,16 @@ public class PostServiceImpl implements PostService {
      */
     @Transactional
     @Override
-    public PostDTO updatePost(Long id, UpdatePostRequest request) {
+    public PostDTO updatePost(Long id, UpdatePostRequest request, UserDetails userDetails) {
+        User user = (User) userDetails;
         log.debug("Updating post with id: {}", id);
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Post not found with id: " + id));
+
+        if (!post.getUser().getId().equals(user.getId())) {
+            log.error("User not authorized to update this post");
+            throw new UnauthorizedException("User not authorized to update this post");
+        }
 
         if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
             log.error("Post title cannot be empty");

--- a/src/main/java/com/tamerm/blog_app/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/tamerm/blog_app/service/impl/PostServiceImpl.java
@@ -9,7 +9,6 @@ import com.tamerm.blog_app.model.Post;
 import com.tamerm.blog_app.model.Tag;
 import com.tamerm.blog_app.model.User;
 import com.tamerm.blog_app.repository.PostRepository;
-import com.tamerm.blog_app.repository.UserRepository;
 import com.tamerm.blog_app.request.CreatePostRequest;
 import com.tamerm.blog_app.request.UpdatePostRequest;
 import com.tamerm.blog_app.service.PostService;
@@ -36,7 +35,6 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
     private final TagService tagService;
     private final ModelMapper modelMapper;
-    private final UserRepository userRepository;
 
     /**
      * Creates a new post.
@@ -132,8 +130,6 @@ public class PostServiceImpl implements PostService {
             throw new BadRequestException("Post title cannot be empty");
         }
 
-        modelMapper.typeMap(UpdatePostRequest.class, Post.class)
-                .addMappings(mapper -> mapper.skip(Post::setTags));
         modelMapper.map(request, post);
 
         if (request.getTags() != null) {

--- a/src/main/java/com/tamerm/blog_app/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/tamerm/blog_app/service/impl/UserServiceImpl.java
@@ -30,6 +30,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
     private final UserRepository userRepository;
     private final JWTService jwtService;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     /**
      * Creates a new user with the given request details.
@@ -43,7 +44,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         log.debug("Creating user with username: {}", request.getUsername());
         User user = new User();
         user.setUsername(request.getUsername());
-        user.setPassword(new BCryptPasswordEncoder().encode(request.getPassword()));
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.setDisplayName(request.getDisplayName());
         User savedUser = userRepository.save(user);
 
@@ -75,7 +76,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         User user = userRepository.findByUsername(request.getUsername())
                 .orElseThrow(() -> new InvalidCredentialsException("Invalid username or password"));
 
-        if (new BCryptPasswordEncoder().matches(request.getPassword(), user.getPassword())) {
+        if (passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             String token = jwtService.generateToken(user);
             log.info("User authenticated successfully with username: {}", request.getUsername());
 

--- a/src/main/java/com/tamerm/blog_app/util/mapper/ModelMapperConfig.java
+++ b/src/main/java/com/tamerm/blog_app/util/mapper/ModelMapperConfig.java
@@ -1,5 +1,7 @@
 package com.tamerm.blog_app.util.mapper;
 
+import com.tamerm.blog_app.model.Post;
+import com.tamerm.blog_app.request.UpdatePostRequest;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +17,8 @@ public class ModelMapperConfig {
     @Qualifier("modelMapper")
     public ModelMapper modelMapper() {
         ModelMapper modelMapper = new ModelMapper();
+        modelMapper.typeMap(UpdatePostRequest.class, Post.class)
+                .addMappings(mapper -> mapper.skip(Post::setTags));
         return modelMapper;
     }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -11,3 +11,5 @@ springdoc.swagger-ui.enabled=true
 springdoc.override-with-generic-response=false
 
 logging.level.org.springdoc=DEBUG
+
+jwt.secret=dev-secret-key-change-me-in-production-must-be-at-least-32-chars

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -8,3 +8,5 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.sql.init.mode=always
 
 logging.level.org.springdoc=INFO
+
+jwt.secret=${JWT_SECRET}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -11,3 +11,5 @@ springdoc.swagger-ui.enabled=true
 springdoc.override-with-generic-response=false
 
 logging.level.org.springdoc=DEBUG
+
+jwt.secret=test-secret-key-change-me-in-production-must-be-at-least-32-chars

--- a/src/test/java/com/tamerm/blog_app/integration/service/impl/PostServiceIntegrationTest.java
+++ b/src/test/java/com/tamerm/blog_app/integration/service/impl/PostServiceIntegrationTest.java
@@ -2,9 +2,7 @@ package com.tamerm.blog_app.integration.service.impl;
 
 import com.tamerm.blog_app.BlogApplication;
 import com.tamerm.blog_app.dto.PostDTO;
-import com.tamerm.blog_app.dto.UserDTO;
 import com.tamerm.blog_app.exception.ResourceNotFoundException;
-import com.tamerm.blog_app.model.User;
 import com.tamerm.blog_app.request.CreatePostRequest;
 import com.tamerm.blog_app.request.CreateUserRequest;
 import com.tamerm.blog_app.request.UpdatePostRequest;
@@ -14,6 +12,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,12 +35,16 @@ public class PostServiceIntegrationTest {
     @Autowired
     private UserService userService;
 
-    private UserDTO user;
+    @Autowired
+    private UserDetailsService userDetailsService;
+
+    private UserDetails userDetails;
 
     @BeforeEach
     void setUp() {
         CreateUserRequest createUserRequest = new CreateUserRequest("testuser", "password", "testuser@example.com");
-        user = userService.createUser(createUserRequest);
+        userService.createUser(createUserRequest);
+        userDetails = userDetailsService.loadUserByUsername("testuser");
     }
 
     /**
@@ -49,7 +53,7 @@ public class PostServiceIntegrationTest {
     @Test
     void createPost_ShouldReturnCreatedPost() {
         CreatePostRequest request = new CreatePostRequest("Integration Test Title", "Integration Test Text", Collections.singletonList("TestTag"));
-        PostDTO createdPost = postService.createPost(request, user.getId(), null);
+        PostDTO createdPost = postService.createPost(request, userDetails);
 
         assertNotNull(createdPost);
         assertEquals("Integration Test Title", createdPost.getTitle());
@@ -61,7 +65,7 @@ public class PostServiceIntegrationTest {
     @Test
     void getPostById_ShouldReturnPost() {
         CreatePostRequest request = new CreatePostRequest("Integration Test Title", "Integration Test Text", Collections.singletonList("TestTag"));
-        PostDTO createdPost = postService.createPost(request, user.getId(),  null);
+        PostDTO createdPost = postService.createPost(request, userDetails);
 
         PostDTO retrievedPost = postService.getPostById(createdPost.getId());
 
@@ -75,7 +79,7 @@ public class PostServiceIntegrationTest {
     @Test
     void updatePost_ShouldReturnUpdatedPost() {
         CreatePostRequest createRequest = new CreatePostRequest("Integration Test Title", "Integration Test Text", Collections.singletonList("TestTag"));
-        PostDTO createdPost = postService.createPost(createRequest, user.getId(), null);
+        PostDTO createdPost = postService.createPost(createRequest, userDetails);
 
         UpdatePostRequest updateRequest = new UpdatePostRequest("Updated Integration Test Title", "Updated Integration Test Text", Collections.singletonList("UpdatedTestTag"));
         PostDTO updatedPost = postService.updatePost(createdPost.getId(), updateRequest);
@@ -90,9 +94,9 @@ public class PostServiceIntegrationTest {
     @Test
     void deletePost_ShouldRemovePost() {
         CreatePostRequest request = new CreatePostRequest("Integration Test Title", "Integration Test Text", Collections.singletonList("TestTag"));
-        PostDTO createdPost = postService.createPost(request, user.getId(), null);
+        PostDTO createdPost = postService.createPost(request, userDetails);
 
-        postService.deletePost(createdPost.getId(), user.getId(),  null);
+        postService.deletePost(createdPost.getId(), userDetails);
 
         assertThrows(ResourceNotFoundException.class, () -> postService.getPostById(createdPost.getId()));
     }

--- a/src/test/java/com/tamerm/blog_app/integration/service/impl/PostServiceIntegrationTest.java
+++ b/src/test/java/com/tamerm/blog_app/integration/service/impl/PostServiceIntegrationTest.java
@@ -82,7 +82,7 @@ public class PostServiceIntegrationTest {
         PostDTO createdPost = postService.createPost(createRequest, userDetails);
 
         UpdatePostRequest updateRequest = new UpdatePostRequest("Updated Integration Test Title", "Updated Integration Test Text", Collections.singletonList("UpdatedTestTag"));
-        PostDTO updatedPost = postService.updatePost(createdPost.getId(), updateRequest);
+        PostDTO updatedPost = postService.updatePost(createdPost.getId(), updateRequest, userDetails);
 
         assertNotNull(updatedPost);
         assertEquals("Updated Integration Test Title", updatedPost.getTitle());

--- a/src/test/java/com/tamerm/blog_app/unit/controller/PostControllerTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/controller/PostControllerTest.java
@@ -109,9 +109,9 @@ class PostControllerTest {
     @Test
     void updatePost_ShouldReturnUpdatedPost() {
         UpdatePostRequest request = new UpdatePostRequest("Updated Title", "Updated Text", Collections.emptyList());
-        Mockito.when(postService.updatePost(anyLong(), any(UpdatePostRequest.class))).thenReturn(postDTO);
+        Mockito.when(postService.updatePost(anyLong(), any(UpdatePostRequest.class), isNull())).thenReturn(postDTO);
 
-        ResponseEntity<PostDTO> response = postController.updatePost(1L, request);
+        ResponseEntity<PostDTO> response = postController.updatePost(1L, request, null);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("Test Title", response.getBody().getTitle());

--- a/src/test/java/com/tamerm/blog_app/unit/controller/PostControllerTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/controller/PostControllerTest.java
@@ -55,9 +55,9 @@ class PostControllerTest {
     @Test
     void createPost_ShouldReturnCreatedPost() {
         CreatePostRequest request = new CreatePostRequest("Test Title", "Test Text", Collections.emptyList());
-        Mockito.when(postService.createPost(any(CreatePostRequest.class), anyLong(), isNull())).thenReturn(postDTO);
+        Mockito.when(postService.createPost(any(CreatePostRequest.class), isNull())).thenReturn(postDTO);
 
-        ResponseEntity<PostDTO> response = postController.createPost(request, 1L, null);
+        ResponseEntity<PostDTO> response = postController.createPost(request, null);
 
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
         assertEquals("Test Title", response.getBody().getTitle());
@@ -122,7 +122,7 @@ class PostControllerTest {
      */
     @Test
     void deletePost_ShouldReturnNoContent() {
-        ResponseEntity<Void> response = postController.deletePost(1L, 1L, null);
+        ResponseEntity<Void> response = postController.deletePost(1L, null);
 
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
     }

--- a/src/test/java/com/tamerm/blog_app/unit/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/service/impl/PostServiceImplTest.java
@@ -80,12 +80,11 @@ class PostServiceImplTest {
      */
     @Test
     void createPost_ShouldReturnCreatedPost() {
-        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user));
         when(modelMapper.map(any(CreatePostRequest.class), eq(Post.class))).thenReturn(post);
         when(postRepository.save(any(Post.class))).thenReturn(post);
         when(modelMapper.map(any(Post.class), eq(PostDTO.class))).thenReturn(postDTO);
 
-        PostDTO result = postService.createPost(createPostRequest, user.getId(), null);
+        PostDTO result = postService.createPost(createPostRequest, user);
 
         assertNotNull(result);
         assertEquals(postDTO.getTitle(), result.getTitle());
@@ -99,7 +98,7 @@ class PostServiceImplTest {
     void createPost_ShouldThrowBadRequestException_WhenTitleIsEmpty() {
         createPostRequest.setTitle("");
 
-        assertThrows(BadRequestException.class, () -> postService.createPost(createPostRequest, user.getId(), null));
+        assertThrows(BadRequestException.class, () -> postService.createPost(createPostRequest, user));
     }
 
     /**
@@ -109,7 +108,7 @@ class PostServiceImplTest {
     void createPost_ShouldThrowBadRequestException_WhenTitleIsNull() {
         createPostRequest.setTitle(null);
 
-        assertThrows(BadRequestException.class, () -> postService.createPost(createPostRequest, user.getId(), null));
+        assertThrows(BadRequestException.class, () -> postService.createPost(createPostRequest, user));
     }
 
     /**
@@ -119,13 +118,12 @@ class PostServiceImplTest {
     void createPost_ShouldHandleTagsProperly() {
         createPostRequest.setTags(List.of("tag1", "tag2"));
         Set<Tag> tags = Set.of(new Tag("tag1"), new Tag("tag2"));
-        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user));
         when(tagService.getOrCreateTags(anyList())).thenReturn(tags);
         when(modelMapper.map(any(CreatePostRequest.class), eq(Post.class))).thenReturn(post);
         when(postRepository.save(any(Post.class))).thenReturn(post);
         when(modelMapper.map(any(Post.class), eq(PostDTO.class))).thenReturn(postDTO);
 
-        PostDTO result = postService.createPost(createPostRequest, user.getId(), null);
+        PostDTO result = postService.createPost(createPostRequest, user);
 
         assertNotNull(result);
         assertEquals(postDTO.getTitle(), result.getTitle());
@@ -200,7 +198,7 @@ class PostServiceImplTest {
     void deletePost_ShouldDeletePost_WhenPostExists() {
         when(postRepository.findById(1L)).thenReturn(Optional.of(post));
 
-        postService.deletePost(1L, 1L, null);
+        postService.deletePost(1L, user);
 
         verify(postRepository, times(1)).delete(post);
     }
@@ -210,9 +208,9 @@ class PostServiceImplTest {
      */
     @Test
     void deletePost_ShouldThrowResourceNotFoundException_WhenPostDoesNotExist() {
-        lenient().when(postRepository.findByIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+        when(postRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThrows(ResourceNotFoundException.class, () -> postService.deletePost(1L, 1L, null));
+        assertThrows(ResourceNotFoundException.class, () -> postService.deletePost(1L, user));
     }
 
     /**

--- a/src/test/java/com/tamerm/blog_app/unit/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/service/impl/PostServiceImplTest.java
@@ -9,7 +9,6 @@ import com.tamerm.blog_app.model.Post;
 import com.tamerm.blog_app.model.Tag;
 import com.tamerm.blog_app.model.User;
 import com.tamerm.blog_app.repository.PostRepository;
-import com.tamerm.blog_app.repository.UserRepository;
 import com.tamerm.blog_app.request.CreatePostRequest;
 import com.tamerm.blog_app.request.UpdatePostRequest;
 import com.tamerm.blog_app.service.TagService;
@@ -40,9 +39,6 @@ class PostServiceImplTest {
 
     @Mock
     private PostRepository postRepository;
-
-    @Mock
-    private UserRepository userRepository;
 
     @Mock
     private TagService tagService;

--- a/src/test/java/com/tamerm/blog_app/unit/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/service/impl/PostServiceImplTest.java
@@ -4,6 +4,7 @@ import com.tamerm.blog_app.dto.PostDTO;
 import com.tamerm.blog_app.dto.PostSummaryDTO;
 import com.tamerm.blog_app.exception.BadRequestException;
 import com.tamerm.blog_app.exception.ResourceNotFoundException;
+import com.tamerm.blog_app.exception.UnauthorizedException;
 import com.tamerm.blog_app.model.Post;
 import com.tamerm.blog_app.model.Tag;
 import com.tamerm.blog_app.model.User;
@@ -178,7 +179,7 @@ class PostServiceImplTest {
         when(postRepository.findById(1L)).thenReturn(Optional.of(post));
         updatePostRequest.setTitle(null);
 
-        assertThrows(BadRequestException.class, () -> postService.updatePost(1L, updatePostRequest));
+        assertThrows(BadRequestException.class, () -> postService.updatePost(1L, updatePostRequest, user));
     }
 
     /**
@@ -188,7 +189,18 @@ class PostServiceImplTest {
     void updatePost_ShouldThrowResourceNotFoundException_WhenPostDoesNotExist() {
         when(postRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThrows(ResourceNotFoundException.class, () -> postService.updatePost(1L, updatePostRequest));
+        assertThrows(ResourceNotFoundException.class, () -> postService.updatePost(1L, updatePostRequest, user));
+    }
+
+    /**
+     * Tests that an UnauthorizedException is thrown when the user does not own the post.
+     */
+    @Test
+    void updatePost_ShouldThrowUnauthorizedException_WhenUserDoesNotOwnPost() {
+        User otherUser = User.builder().id(99L).username("other").password("pw").build();
+        when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+
+        assertThrows(UnauthorizedException.class, () -> postService.updatePost(1L, updatePostRequest, otherUser));
     }
 
     /**

--- a/src/test/java/com/tamerm/blog_app/unit/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/service/impl/UserServiceImplTest.java
@@ -32,6 +32,9 @@ public class UserServiceImplTest {
     @Mock
     private JWTService jwtService;
 
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
     @InjectMocks
     private UserServiceImpl userService;
 
@@ -48,7 +51,7 @@ public class UserServiceImplTest {
         user = new User();
         user.setId(1L);
         user.setUsername("testuser");
-        user.setPassword(new BCryptPasswordEncoder().encode("password"));
+        user.setPassword("hashed-password");
         user.setDisplayName("Test User");
 
         createUserRequest = new CreateUserRequest();
@@ -82,6 +85,7 @@ public class UserServiceImplTest {
     void login_ShouldReturnJwtToken() {
         when(userRepository.findByUsername(any(String.class))).thenReturn(Optional.of(user));
         when(jwtService.generateToken(any(User.class))).thenReturn("jwt-token");
+        when(passwordEncoder.matches("password", "hashed-password")).thenReturn(true);
 
         String result = userService.login(loginRequest);
 
@@ -111,6 +115,7 @@ public class UserServiceImplTest {
         when(userRepository.save(any(User.class))).thenReturn(user);
         when(userRepository.findByUsername(any(String.class))).thenReturn(Optional.of(user));
         when(jwtService.generateToken(any(User.class))).thenReturn("jwt-token");
+        when(passwordEncoder.matches("password", "hashed-password")).thenReturn(true);
 
         CreateUserRequest createUserRequest = new CreateUserRequest("testuser", "password", "Test User");
         userService.createUser(createUserRequest);


### PR DESCRIPTION
## Summary

6 security and code quality fixes identified during v0.2.0 code review, each in a separate commit.

- **JWT secret key externalized** — was generated at runtime, invalidating all tokens on restart. Now read from `application.properties` / `JWT_SECRET` env var in prod.
- **Auth bypass closed** — `userId` was accepted as a `@RequestParam`, allowing any caller to forge another user's identity. Now derived from the authenticated JWT principal. POST and PUT `/posts/**` also require authentication.
- **`updatePost()` ownership check added** — any authenticated user could update another user's post. Now throws `UnauthorizedException` if caller doesn't own the post.
- **`BCryptPasswordEncoder` as Spring Bean** — was instantiated inline on every call. Now a singleton in `PasswordEncoderConfig` (separate class to avoid circular dependency with `SecurityConfig`).
- **`SecurityConfig` depends on interface** — was injecting `JWTServiceImpl` directly; changed to `JWTService` interface (Dependency Inversion Principle).
- **ModelMapper `typeMap` registered once** — was added to the singleton `ModelMapper` on every `updatePost()` call, risking race conditions. Moved to `ModelMapperConfig` startup. Unused `UserRepository` dependency removed from `PostServiceImpl`.

## Test plan

- [x] All 51 unit tests pass (`mvn test -Dtest="**/unit/**,**/security/**,BlogApplicationTests"`)
- [ ] Integration tests pass with Docker running (`mvn test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)