### PR TITLE
v0.3.0 — Pagination, Search, SonarQube, Media

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,16 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm</artifactId>
+            <version>7.2.2.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-lucene</artifactId>
+            <version>7.2.2.Final</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,11 @@
             <artifactId>hibernate-search-backend-lucene</artifactId>
             <version>7.2.2.Final</version>
         </dependency>
+        <dependency>
+            <groupId>net.coobird</groupId>
+            <artifactId>thumbnailator</artifactId>
+            <version>0.4.20</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.tamerm</groupId>
     <artifactId>blog-app</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.3.0</version>
     <name>Blog Application</name>
     <description>Blog application project</description>
     <url/>
@@ -28,6 +28,11 @@
     </scm>
     <properties>
         <java.version>21</java.version>
+        <sonar.projectKey>blog-app</sonar.projectKey>
+        <sonar.projectName>Blog Application</sonar.projectName>
+        <sonar.host.url>http://localhost:9000</sonar.host.url>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.exclusions>**/model/**,**/dto/**,**/request/**,**/config/**,**/BlogApplication.java</sonar.exclusions>
     </properties>
     <dependencies>
         <dependency>
@@ -156,6 +161,40 @@
                         </exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>**/model/**</exclude>
+                        <exclude>**/dto/**</exclude>
+                        <exclude>**/request/**</exclude>
+                        <exclude>**/config/**</exclude>
+                        <exclude>**/BlogApplication.class</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>3.11.0.3922</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/tamerm/blog_app/config/SearchIndexingConfig.java
+++ b/src/main/java/com/tamerm/blog_app/config/SearchIndexingConfig.java
@@ -1,0 +1,40 @@
+package com.tamerm.blog_app.config;
+
+import com.tamerm.blog_app.model.Post;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Triggers a full reindex of all Post entities on application startup
+ * so that any data already in the database is searchable immediately.
+ */
+@Component
+@Slf4j
+public class SearchIndexingConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void indexOnStartup() {
+        log.info("Starting Hibernate Search mass indexing...");
+        try {
+            SearchSession searchSession = Search.session(entityManager);
+            searchSession.massIndexer(Post.class)
+                    .threadsToLoadObjects(2)
+                    .startAndWait();
+            log.info("Hibernate Search mass indexing completed.");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Hibernate Search mass indexing was interrupted.", e);
+        }
+    }
+}

--- a/src/main/java/com/tamerm/blog_app/controller/MediaController.java
+++ b/src/main/java/com/tamerm/blog_app/controller/MediaController.java
@@ -1,0 +1,86 @@
+package com.tamerm.blog_app.controller;
+
+import com.tamerm.blog_app.dto.MediaDTO;
+import com.tamerm.blog_app.service.MediaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Media Controller", description = "APIs for managing post media (images and videos)")
+@SecurityRequirement(name = "bearerAuth")
+public class MediaController {
+
+    private final MediaService mediaService;
+
+    @PostMapping("/posts/{postId}/media")
+    @Operation(summary = "Upload media to a post",
+            description = "Images are stored in ORIGINAL, LARGE, MEDIUM and SMALL variants. Videos are stored as-is.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Media uploaded successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "Post not found")
+    })
+    public ResponseEntity<List<MediaDTO>> uploadMedia(
+            @PathVariable Long postId,
+            @RequestParam("file") MultipartFile file,
+            @AuthenticationPrincipal UserDetails userDetails) throws IOException {
+        List<MediaDTO> result = mediaService.addMedia(postId, file, userDetails);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    @DeleteMapping("/posts/{postId}/media/{groupId}")
+    @Operation(summary = "Remove media from a post",
+            description = "Deletes all resolution variants of the specified media upload.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Media removed successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "Post or media not found")
+    })
+    public ResponseEntity<Void> removeMedia(
+            @PathVariable Long postId,
+            @PathVariable String groupId,
+            @AuthenticationPrincipal UserDetails userDetails) throws IOException {
+        mediaService.removeMedia(postId, groupId, userDetails);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/media/{mediaId}")
+    @Operation(summary = "Download a media file", description = "Serves the media file by its ID.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "File served successfully"),
+            @ApiResponse(responseCode = "404", description = "Media not found")
+    })
+    public ResponseEntity<Resource> downloadMedia(@PathVariable Long mediaId) throws IOException {
+        Path filePath = mediaService.resolveFilePath(mediaId);
+        Resource resource = new UrlResource(filePath.toUri());
+        String contentType = java.nio.file.Files.probeContentType(filePath);
+        if (contentType == null) {
+            contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
+        }
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(contentType))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + filePath.getFileName() + "\"")
+                .body(resource);
+    }
+}

--- a/src/main/java/com/tamerm/blog_app/controller/PostController.java
+++ b/src/main/java/com/tamerm/blog_app/controller/PostController.java
@@ -13,13 +13,13 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 /**
  * REST controller for managing posts.
@@ -61,12 +61,14 @@ public class PostController {
      * @return a list of post summaries
      */
     @GetMapping
-    @Operation(summary = "Get all post summaries", description = "Retrieves a list of all post summaries")
+    @Operation(summary = "Get all post summaries", description = "Retrieves a paginated list of all post summaries")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "List of post summaries retrieved successfully")
     })
-    public ResponseEntity<List<PostSummaryDTO>> getAllPostSummaries() {
-        List<PostSummaryDTO> posts = postService.getAllPosts();
+    public ResponseEntity<Page<PostSummaryDTO>> getAllPostSummaries(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Page<PostSummaryDTO> posts = postService.getAllPosts(PageRequest.of(page, size));
         return ResponseEntity.ok(posts);
     }
 
@@ -142,13 +144,15 @@ public class PostController {
      * @return a list of posts with the specified tag name
      */
     @GetMapping("/byTag/{tagName}")
-    @Operation(summary = "Get posts by tag name", description = "Retrieves a list of posts with the specified tag name")
+    @Operation(summary = "Get posts by tag name", description = "Retrieves a paginated list of posts with the specified tag name")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "List of posts retrieved successfully")
     })
-    public ResponseEntity<List<PostSummaryDTO>> getPostsByTag(
-            @PathVariable @Parameter(description = "Name of the tag") String tagName) {
-        List<PostSummaryDTO> posts = postService.getPostsByTagName(tagName);
+    public ResponseEntity<Page<PostSummaryDTO>> getPostsByTag(
+            @PathVariable @Parameter(description = "Name of the tag") String tagName,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Page<PostSummaryDTO> posts = postService.getPostsByTagName(tagName, PageRequest.of(page, size));
         return ResponseEntity.ok(posts);
     }
 }

--- a/src/main/java/com/tamerm/blog_app/controller/PostController.java
+++ b/src/main/java/com/tamerm/blog_app/controller/PostController.java
@@ -143,6 +143,27 @@ public class PostController {
      * @param tagName the name of the tag
      * @return a list of posts with the specified tag name
      */
+    /**
+     * Search posts by a free-text query (word, sentence, or tag).
+     *
+     * @param q    the search query
+     * @param page page number (0-based)
+     * @param size page size
+     * @return paginated search results
+     */
+    @GetMapping("/search")
+    @Operation(summary = "Search posts", description = "Full-text search across post title, text and tags")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Search results retrieved successfully")
+    })
+    public ResponseEntity<Page<PostSummaryDTO>> searchPosts(
+            @RequestParam @Parameter(description = "Search query (word, sentence, or tag)") String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Page<PostSummaryDTO> results = postService.searchPosts(q, PageRequest.of(page, size));
+        return ResponseEntity.ok(results);
+    }
+
     @GetMapping("/byTag/{tagName}")
     @Operation(summary = "Get posts by tag name", description = "Retrieves a paginated list of posts with the specified tag name")
     @ApiResponses({

--- a/src/main/java/com/tamerm/blog_app/dto/MediaDTO.java
+++ b/src/main/java/com/tamerm/blog_app/dto/MediaDTO.java
@@ -1,0 +1,24 @@
+package com.tamerm.blog_app.dto;
+
+import com.tamerm.blog_app.model.MediaResolution;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Data Transfer Object for media files attached to a post.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MediaDTO {
+    private Long id;
+    private String fileName;
+    private String contentType;
+    private long fileSize;
+    private MediaResolution resolution;
+    private String groupId;
+    private String downloadUrl;
+}

--- a/src/main/java/com/tamerm/blog_app/dto/PostDTO.java
+++ b/src/main/java/com/tamerm/blog_app/dto/PostDTO.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -18,4 +19,5 @@ public class PostDTO {
     private String title;
     private String text;
     private Set<Tag> tags;
+    private List<MediaDTO> mediaFiles;
 }

--- a/src/main/java/com/tamerm/blog_app/model/Media.java
+++ b/src/main/java/com/tamerm/blog_app/model/Media.java
@@ -1,0 +1,51 @@
+package com.tamerm.blog_app.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Entity representing a media file (image or video) attached to a blog post.
+ * Image uploads produce one record per resolution variant (ORIGINAL, LARGE, MEDIUM, SMALL).
+ * All variants of the same upload share the same groupId.
+ */
+@Entity
+@Table(name = "media")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Media {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String contentType;
+
+    private long fileSize;
+
+    @Column(nullable = false)
+    private String filePath;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MediaResolution resolution;
+
+    /**
+     * Shared identifier for all resolution variants of the same upload.
+     * Used to retrieve or delete all variants together.
+     */
+    @Column(nullable = false)
+    private String groupId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+}

--- a/src/main/java/com/tamerm/blog_app/model/MediaResolution.java
+++ b/src/main/java/com/tamerm/blog_app/model/MediaResolution.java
@@ -1,0 +1,12 @@
+package com.tamerm.blog_app.model;
+
+/**
+ * Represents the display resolution variant of a media file.
+ * Image uploads are stored in all four variants; videos are stored as ORIGINAL only.
+ */
+public enum MediaResolution {
+    ORIGINAL,
+    LARGE,   // 1280px wide
+    MEDIUM,  // 640px wide
+    SMALL    // 320px wide
+}

--- a/src/main/java/com/tamerm/blog_app/model/Post.java
+++ b/src/main/java/com/tamerm/blog_app/model/Post.java
@@ -4,6 +4,11 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -12,6 +17,7 @@ import java.util.Set;
  * Entity representing a blog post.
  */
 @Entity
+@Indexed
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -22,9 +28,11 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @FullTextField
     @Column(nullable = false)
     private String title;
 
+    @FullTextField
     @Column(nullable = false)
     private String text;
 
@@ -32,6 +40,8 @@ public class Post {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @IndexedEmbedded
+    @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
     @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinTable(
             name = "post_tags",

--- a/src/main/java/com/tamerm/blog_app/model/Post.java
+++ b/src/main/java/com/tamerm/blog_app/model/Post.java
@@ -10,7 +10,9 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -49,4 +51,7 @@ public class Post {
             inverseJoinColumns = @JoinColumn(name = "tag_id", referencedColumnName = "id")
     )
     private Set<Tag> tags = new HashSet<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Media> mediaFiles = new java.util.ArrayList<>();
 }

--- a/src/main/java/com/tamerm/blog_app/model/Tag.java
+++ b/src/main/java/com/tamerm/blog_app/model/Tag.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
 /**
  * Entity representing a tag.
@@ -19,6 +20,7 @@ public class Tag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @KeywordField
     @Column(nullable = false, unique = true)
     private String name;
 

--- a/src/main/java/com/tamerm/blog_app/repository/MediaRepository.java
+++ b/src/main/java/com/tamerm/blog_app/repository/MediaRepository.java
@@ -1,0 +1,14 @@
+package com.tamerm.blog_app.repository;
+
+import com.tamerm.blog_app.model.Media;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MediaRepository extends JpaRepository<Media, Long> {
+
+    List<Media> findAllByGroupId(String groupId);
+
+    Optional<Media> findByIdAndPost_Id(Long id, Long postId);
+}

--- a/src/main/java/com/tamerm/blog_app/repository/PostRepository.java
+++ b/src/main/java/com/tamerm/blog_app/repository/PostRepository.java
@@ -1,11 +1,12 @@
 package com.tamerm.blog_app.repository;
 
 import com.tamerm.blog_app.model.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -20,7 +21,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
      * @return a list of posts with the specified tag name
      */
     @Query("SELECT p FROM Post p JOIN p.tags t WHERE t.name = :tagName")
-    List<Post> findAllByTags_Name(String tagName);
+    Page<Post> findAllByTags_Name(String tagName, Pageable pageable);
 
     /**
      * Find a post by its ID and user ID.

--- a/src/main/java/com/tamerm/blog_app/security/SecurityConfig.java
+++ b/src/main/java/com/tamerm/blog_app/security/SecurityConfig.java
@@ -34,6 +34,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT, "/posts/**").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/posts/**").authenticated()
                         .requestMatchers("/posts/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/media/**").permitAll()
+                        .requestMatchers("/media/**").authenticated()
                         .anyRequest().authenticated()
                 )
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))

--- a/src/main/java/com/tamerm/blog_app/service/FileStorageService.java
+++ b/src/main/java/com/tamerm/blog_app/service/FileStorageService.java
@@ -1,0 +1,33 @@
+package com.tamerm.blog_app.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public interface FileStorageService {
+
+    /**
+     * Stores a file under the given sub-path relative to the storage root.
+     *
+     * @param file    the multipart file to store
+     * @param subPath relative path including file name (e.g. "groupId/ORIGINAL_filename.jpg")
+     * @return the absolute path where the file was stored
+     */
+    Path store(MultipartFile file, String subPath) throws IOException;
+
+    /**
+     * Stores raw bytes under the given sub-path.
+     */
+    Path storeBytes(byte[] bytes, String subPath) throws IOException;
+
+    /**
+     * Resolves the absolute path for a given sub-path.
+     */
+    Path resolve(String subPath);
+
+    /**
+     * Deletes the file at the given sub-path.
+     */
+    void delete(String subPath) throws IOException;
+}

--- a/src/main/java/com/tamerm/blog_app/service/MediaService.java
+++ b/src/main/java/com/tamerm/blog_app/service/MediaService.java
@@ -1,0 +1,31 @@
+package com.tamerm.blog_app.service;
+
+import com.tamerm.blog_app.dto.MediaDTO;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+public interface MediaService {
+
+    /**
+     * Attaches a media file to a post.
+     * Images are stored in ORIGINAL, LARGE, MEDIUM and SMALL resolution variants.
+     * Videos are stored as ORIGINAL only.
+     *
+     * @return list of created MediaDTO records (one per resolution variant)
+     */
+    List<MediaDTO> addMedia(Long postId, MultipartFile file, UserDetails userDetails) throws IOException;
+
+    /**
+     * Removes all resolution variants of a media upload identified by groupId.
+     */
+    void removeMedia(Long postId, String groupId, UserDetails userDetails) throws IOException;
+
+    /**
+     * Resolves the filesystem path for a specific media record.
+     */
+    Path resolveFilePath(Long mediaId);
+}

--- a/src/main/java/com/tamerm/blog_app/service/PostService.java
+++ b/src/main/java/com/tamerm/blog_app/service/PostService.java
@@ -15,4 +15,5 @@ public interface PostService {
     PostDTO updatePost(Long id, UpdatePostRequest request, UserDetails userDetails);
     void deletePost(Long postId, UserDetails userDetails);
     Page<PostSummaryDTO> getPostsByTagName(String tagName, Pageable pageable);
+    Page<PostSummaryDTO> searchPosts(String query, Pageable pageable);
 }

--- a/src/main/java/com/tamerm/blog_app/service/PostService.java
+++ b/src/main/java/com/tamerm/blog_app/service/PostService.java
@@ -4,15 +4,15 @@ import com.tamerm.blog_app.dto.PostDTO;
 import com.tamerm.blog_app.dto.PostSummaryDTO;
 import com.tamerm.blog_app.request.CreatePostRequest;
 import com.tamerm.blog_app.request.UpdatePostRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.List;
 
 public interface PostService {
     PostDTO createPost(CreatePostRequest request, UserDetails userDetails);
-    List<PostSummaryDTO> getAllPosts();
+    Page<PostSummaryDTO> getAllPosts(Pageable pageable);
     PostDTO getPostById(Long id);
     PostDTO updatePost(Long id, UpdatePostRequest request, UserDetails userDetails);
     void deletePost(Long postId, UserDetails userDetails);
-    List<PostSummaryDTO> getPostsByTagName(String tagName);
+    Page<PostSummaryDTO> getPostsByTagName(String tagName, Pageable pageable);
 }

--- a/src/main/java/com/tamerm/blog_app/service/impl/FileStorageServiceImpl.java
+++ b/src/main/java/com/tamerm/blog_app/service/impl/FileStorageServiceImpl.java
@@ -1,0 +1,61 @@
+package com.tamerm.blog_app.service.impl;
+
+import com.tamerm.blog_app.service.FileStorageService;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+@Service
+@Slf4j
+public class FileStorageServiceImpl implements FileStorageService {
+
+    private final Path storageRoot;
+
+    public FileStorageServiceImpl(@Value("${app.media.storage-path}") String storagePath) {
+        this.storageRoot = Paths.get(storagePath).toAbsolutePath().normalize();
+    }
+
+    @PostConstruct
+    public void init() throws IOException {
+        Files.createDirectories(storageRoot);
+        log.info("Media storage root: {}", storageRoot);
+    }
+
+    @Override
+    public Path store(MultipartFile file, String subPath) throws IOException {
+        Path target = storageRoot.resolve(subPath).normalize();
+        Files.createDirectories(target.getParent());
+        Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
+        log.debug("Stored file: {}", target);
+        return target;
+    }
+
+    @Override
+    public Path storeBytes(byte[] bytes, String subPath) throws IOException {
+        Path target = storageRoot.resolve(subPath).normalize();
+        Files.createDirectories(target.getParent());
+        Files.write(target, bytes);
+        log.debug("Stored resized file: {}", target);
+        return target;
+    }
+
+    @Override
+    public Path resolve(String subPath) {
+        return storageRoot.resolve(subPath).normalize();
+    }
+
+    @Override
+    public void delete(String subPath) throws IOException {
+        Path target = storageRoot.resolve(subPath).normalize();
+        Files.deleteIfExists(target);
+        log.debug("Deleted file: {}", target);
+    }
+}

--- a/src/main/java/com/tamerm/blog_app/service/impl/MediaServiceImpl.java
+++ b/src/main/java/com/tamerm/blog_app/service/impl/MediaServiceImpl.java
@@ -1,0 +1,146 @@
+package com.tamerm.blog_app.service.impl;
+
+import com.tamerm.blog_app.dto.MediaDTO;
+import com.tamerm.blog_app.exception.ResourceNotFoundException;
+import com.tamerm.blog_app.exception.UnauthorizedException;
+import com.tamerm.blog_app.model.Media;
+import com.tamerm.blog_app.model.MediaResolution;
+import com.tamerm.blog_app.model.Post;
+import com.tamerm.blog_app.model.User;
+import com.tamerm.blog_app.repository.MediaRepository;
+import com.tamerm.blog_app.repository.PostRepository;
+import com.tamerm.blog_app.service.FileStorageService;
+import com.tamerm.blog_app.service.MediaService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnails;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MediaServiceImpl implements MediaService {
+
+    private static final int[] IMAGE_WIDTHS = {1280, 640, 320};
+    private static final MediaResolution[] IMAGE_RESOLUTIONS = {
+            MediaResolution.LARGE, MediaResolution.MEDIUM, MediaResolution.SMALL
+    };
+
+    private final MediaRepository mediaRepository;
+    private final PostRepository postRepository;
+    private final FileStorageService fileStorageService;
+
+    @Transactional
+    @Override
+    public List<MediaDTO> addMedia(Long postId, MultipartFile file, UserDetails userDetails) throws IOException {
+        User user = (User) userDetails;
+        Post post = findPostAndVerifyOwner(postId, user);
+
+        String groupId = UUID.randomUUID().toString();
+        String originalFileName = file.getOriginalFilename();
+        String contentType = file.getContentType() != null ? file.getContentType() : "application/octet-stream";
+
+        List<Media> savedMedia = new ArrayList<>();
+
+        // Always store the original
+        String originalSubPath = groupId + "/ORIGINAL_" + originalFileName;
+        fileStorageService.store(file, originalSubPath);
+        savedMedia.add(mediaRepository.save(Media.builder()
+                .fileName(originalFileName)
+                .contentType(contentType)
+                .fileSize(file.getSize())
+                .filePath(originalSubPath)
+                .resolution(MediaResolution.ORIGINAL)
+                .groupId(groupId)
+                .post(post)
+                .build()));
+
+        // For images, generate additional resolution variants
+        if (contentType.startsWith("image/")) {
+            byte[] originalBytes = file.getBytes();
+            for (int i = 0; i < IMAGE_WIDTHS.length; i++) {
+                int width = IMAGE_WIDTHS[i];
+                MediaResolution resolution = IMAGE_RESOLUTIONS[i];
+                String format = contentType.equals("image/png") ? "png" : "jpg";
+
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                Thumbnails.of(new java.io.ByteArrayInputStream(originalBytes))
+                        .width(width)
+                        .outputFormat(format)
+                        .toOutputStream(baos);
+
+                String subPath = groupId + "/" + resolution.name() + "_" + originalFileName;
+                fileStorageService.storeBytes(baos.toByteArray(), subPath);
+
+                savedMedia.add(mediaRepository.save(Media.builder()
+                        .fileName(resolution.name().toLowerCase() + "_" + originalFileName)
+                        .contentType(contentType)
+                        .fileSize(baos.size())
+                        .filePath(subPath)
+                        .resolution(resolution)
+                        .groupId(groupId)
+                        .post(post)
+                        .build()));
+            }
+        }
+
+        log.info("Added {} media variant(s) to post {}", savedMedia.size(), postId);
+        return savedMedia.stream().map(this::toDTO).toList();
+    }
+
+    @Transactional
+    @Override
+    public void removeMedia(Long postId, String groupId, UserDetails userDetails) throws IOException {
+        User user = (User) userDetails;
+        findPostAndVerifyOwner(postId, user);
+
+        List<Media> variants = mediaRepository.findAllByGroupId(groupId);
+        if (variants.isEmpty()) {
+            throw new ResourceNotFoundException("Media not found with groupId: " + groupId);
+        }
+
+        for (Media media : variants) {
+            fileStorageService.delete(media.getFilePath());
+        }
+        mediaRepository.deleteAll(variants);
+        log.info("Removed {} media variant(s) (groupId={}) from post {}", variants.size(), groupId, postId);
+    }
+
+    @Override
+    public Path resolveFilePath(Long mediaId) {
+        Media media = mediaRepository.findById(mediaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Media not found with id: " + mediaId));
+        return fileStorageService.resolve(media.getFilePath());
+    }
+
+    private Post findPostAndVerifyOwner(Long postId, User user) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException("Post not found with id: " + postId));
+        if (!post.getUser().getId().equals(user.getId())) {
+            throw new UnauthorizedException("User not authorized to modify media on this post");
+        }
+        return post;
+    }
+
+    private MediaDTO toDTO(Media media) {
+        return MediaDTO.builder()
+                .id(media.getId())
+                .fileName(media.getFileName())
+                .contentType(media.getContentType())
+                .fileSize(media.getFileSize())
+                .resolution(media.getResolution())
+                .groupId(media.getGroupId())
+                .downloadUrl("/media/" + media.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/tamerm/blog_app/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/tamerm/blog_app/service/impl/PostServiceImpl.java
@@ -13,10 +13,15 @@ import com.tamerm.blog_app.request.CreatePostRequest;
 import com.tamerm.blog_app.request.UpdatePostRequest;
 import com.tamerm.blog_app.service.PostService;
 import com.tamerm.blog_app.service.TagService;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.search.loading.dsl.SearchLoadingOptionsStep;
+import org.hibernate.search.engine.search.query.SearchResult;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
@@ -37,6 +42,7 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
     private final TagService tagService;
     private final ModelMapper modelMapper;
+    private final EntityManager entityManager;
 
     /**
      * Creates a new post.
@@ -185,6 +191,36 @@ public class PostServiceImpl implements PostService {
      * @param tagName the name of the tag
      * @return a list of posts with the specified tag name
      */
+    /**
+     * Searches posts by full-text query across title, text, and tag names.
+     *
+     * @param query    the search query (word, sentence, or tag)
+     * @param pageable pagination parameters
+     * @return a page of matching post summaries
+     */
+    @Override
+    public Page<PostSummaryDTO> searchPosts(String query, Pageable pageable) {
+        log.debug("Searching posts with query: '{}', page={}, size={}", query, pageable.getPageNumber(), pageable.getPageSize());
+        SearchResult<Post> result = Search.session(entityManager)
+                .search(Post.class)
+                .where(f -> f.simpleQueryString()
+                        .fields("title", "text", "tags.name")
+                        .matching(query))
+                .fetch((int) pageable.getOffset(), pageable.getPageSize());
+
+        List<PostSummaryDTO> content = result.hits().stream()
+                .map(post -> new PostSummaryDTO(
+                        post.getTitle(),
+                        (post.getText() != null && !post.getText().isEmpty())
+                                ? post.getText().substring(0, Math.min(post.getText().length(), 50)) + "..."
+                                : "No content available"
+                ))
+                .collect(Collectors.toList());
+
+        log.info("Search for '{}' returned {} total hits", query, result.total().hitCount());
+        return new PageImpl<>(content, pageable, result.total().hitCount());
+    }
+
     @Override
     public Page<PostSummaryDTO> getPostsByTagName(String tagName, Pageable pageable) {
         log.debug("Retrieving posts with tag: {}, page={}, size={}", tagName, pageable.getPageNumber(), pageable.getPageSize());

--- a/src/main/java/com/tamerm/blog_app/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/tamerm/blog_app/service/impl/PostServiceImpl.java
@@ -16,6 +16,8 @@ import com.tamerm.blog_app.service.TagService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,16 +77,15 @@ public class PostServiceImpl implements PostService {
      * @return a list of post summaries
      */
     @Override
-    public List<PostSummaryDTO> getAllPosts() {
-        log.debug("Retrieving all posts");
-        return postRepository.findAll().stream()
+    public Page<PostSummaryDTO> getAllPosts(Pageable pageable) {
+        log.debug("Retrieving all posts, page={}, size={}", pageable.getPageNumber(), pageable.getPageSize());
+        return postRepository.findAll(pageable)
                 .map(post -> new PostSummaryDTO(
                         post.getTitle(),
-                        (post.getText() != null && post.getText().length() > 0)
+                        (post.getText() != null && !post.getText().isEmpty())
                                 ? post.getText().substring(0, Math.min(post.getText().length(), 50)) + "..."
                                 : "No content available"
-                ))
-                .collect(Collectors.toList());
+                ));
     }
 
     /**
@@ -185,10 +186,14 @@ public class PostServiceImpl implements PostService {
      * @return a list of posts with the specified tag name
      */
     @Override
-    public List<PostSummaryDTO> getPostsByTagName(String tagName) {
-        log.debug("Retrieving posts with tag: {}", tagName);
-        return postRepository.findAllByTags_Name(tagName).stream()
-                .map(post -> new PostSummaryDTO(post.getTitle(), post.getText().substring(0, Math.min(post.getText().length(), 50)) + "..."))
-                .collect(Collectors.toList());
+    public Page<PostSummaryDTO> getPostsByTagName(String tagName, Pageable pageable) {
+        log.debug("Retrieving posts with tag: {}, page={}, size={}", tagName, pageable.getPageNumber(), pageable.getPageSize());
+        return postRepository.findAllByTags_Name(tagName, pageable)
+                .map(post -> new PostSummaryDTO(
+                        post.getTitle(),
+                        (post.getText() != null && !post.getText().isEmpty())
+                                ? post.getText().substring(0, Math.min(post.getText().length(), 50)) + "..."
+                                : "No content available"
+                ));
     }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -17,3 +17,5 @@ jwt.secret=dev-secret-key-change-me-in-production-must-be-at-least-32-chars
 spring.jpa.properties.hibernate.search.backend.type=lucene
 spring.jpa.properties.hibernate.search.backend.directory.root=./lucene-index
 spring.jpa.properties.hibernate.search.schema_management.strategy=create-or-update
+
+app.media.storage-path=./media-storage

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -13,3 +13,7 @@ springdoc.override-with-generic-response=false
 logging.level.org.springdoc=DEBUG
 
 jwt.secret=dev-secret-key-change-me-in-production-must-be-at-least-32-chars
+
+spring.jpa.properties.hibernate.search.backend.type=lucene
+spring.jpa.properties.hibernate.search.backend.directory.root=./lucene-index
+spring.jpa.properties.hibernate.search.schema_management.strategy=create-or-update

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -10,3 +10,7 @@ spring.sql.init.mode=always
 logging.level.org.springdoc=INFO
 
 jwt.secret=${JWT_SECRET}
+
+spring.jpa.properties.hibernate.search.backend.type=lucene
+spring.jpa.properties.hibernate.search.backend.directory.root=./lucene-index
+spring.jpa.properties.hibernate.search.schema_management.strategy=create-or-update

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -14,3 +14,5 @@ jwt.secret=${JWT_SECRET}
 spring.jpa.properties.hibernate.search.backend.type=lucene
 spring.jpa.properties.hibernate.search.backend.directory.root=./lucene-index
 spring.jpa.properties.hibernate.search.schema_management.strategy=create-or-update
+
+app.media.storage-path=${MEDIA_STORAGE_PATH:./media-storage}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -17,3 +17,5 @@ jwt.secret=test-secret-key-change-me-in-production-must-be-at-least-32-chars
 spring.jpa.properties.hibernate.search.backend.type=lucene
 spring.jpa.properties.hibernate.search.backend.directory.type=local-heap
 spring.jpa.properties.hibernate.search.schema_management.strategy=create-or-validate
+
+app.media.storage-path=./test-media-storage

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -13,3 +13,7 @@ springdoc.override-with-generic-response=false
 logging.level.org.springdoc=DEBUG
 
 jwt.secret=test-secret-key-change-me-in-production-must-be-at-least-32-chars
+
+spring.jpa.properties.hibernate.search.backend.type=lucene
+spring.jpa.properties.hibernate.search.backend.directory.type=local-heap
+spring.jpa.properties.hibernate.search.schema_management.strategy=create-or-validate

--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -25,3 +25,31 @@ services:
       MYSQL_PASSWORD: tamerm
     ports:
       - "3307:3306"
+  sonarqube:
+    image: sonarqube:10.4-community
+    container_name: blog-app-sonarqube
+    depends_on:
+      - sonar-db
+    environment:
+      SONAR_JDBC_URL: jdbc:postgresql://sonar-db:5432/sonarqube
+      SONAR_JDBC_USERNAME: sonar
+      SONAR_JDBC_PASSWORD: sonar
+    ports:
+      - "9000:9000"
+    volumes:
+      - sonarqube_data:/opt/sonarqube/data
+      - sonarqube_logs:/opt/sonarqube/logs
+  sonar-db:
+    image: postgres:15-alpine
+    container_name: blog-app-sonar-db
+    environment:
+      POSTGRES_USER: sonar
+      POSTGRES_PASSWORD: sonar
+      POSTGRES_DB: sonarqube
+    volumes:
+      - sonar_db_data:/var/lib/postgresql/data
+
+volumes:
+  sonarqube_data:
+  sonarqube_logs:
+  sonar_db_data:

--- a/src/test/java/com/tamerm/blog_app/integration/repository/PostRepositoryIntegrationTest.java
+++ b/src/test/java/com/tamerm/blog_app/integration/repository/PostRepositoryIntegrationTest.java
@@ -15,7 +15,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -64,11 +65,11 @@ public class PostRepositoryIntegrationTest {
         postRepository.save(post);
 
         // Fetch posts by tag name
-        List<Post> posts = postRepository.findAllByTags_Name("testtag");
+        Page<Post> posts = postRepository.findAllByTags_Name("testtag", PageRequest.of(0, 10));
 
         // Assert that the posts list is not empty and contains the created post
         assertFalse(posts.isEmpty());
-        assertTrue(posts.contains(post));
+        assertTrue(posts.getContent().contains(post));
     }
 
     /**
@@ -76,7 +77,7 @@ public class PostRepositoryIntegrationTest {
      */
     @Test
     void findAllByTags_Name_ShouldReturnEmptyList_WhenNoPostsWithTag() {
-        List<Post> posts = postRepository.findAllByTags_Name("nonexistentTag");
+        Page<Post> posts = postRepository.findAllByTags_Name("nonexistentTag", PageRequest.of(0, 10));
 
         assertNotNull(posts);
         assertTrue(posts.isEmpty());

--- a/src/test/java/com/tamerm/blog_app/integration/service/impl/PostServiceIntegrationTest.java
+++ b/src/test/java/com/tamerm/blog_app/integration/service/impl/PostServiceIntegrationTest.java
@@ -17,6 +17,9 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/tamerm/blog_app/unit/controller/PostControllerTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/controller/PostControllerTest.java
@@ -19,6 +19,10 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -68,12 +72,12 @@ class PostControllerTest {
      */
     @Test
     void getAllPostSummaries_ShouldReturnAllPosts() {
-        Mockito.when(postService.getAllPosts()).thenReturn(List.of(postSummaryDTO));
+        Mockito.when(postService.getAllPosts(PageRequest.of(0, 10))).thenReturn(new PageImpl<>(List.of(postSummaryDTO)));
 
-        ResponseEntity<List<PostSummaryDTO>> response = postController.getAllPostSummaries();
+        ResponseEntity<Page<PostSummaryDTO>> response = postController.getAllPostSummaries(0, 10);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals("Test Title", response.getBody().get(0).getTitle());
+        assertEquals("Test Title", response.getBody().getContent().get(0).getTitle());
     }
 
     /**
@@ -132,11 +136,11 @@ class PostControllerTest {
      */
     @Test
     void getPostsByTag_ShouldReturnPosts() {
-        Mockito.when(postService.getPostsByTagName("tag")).thenReturn(List.of(postSummaryDTO));
+        Mockito.when(postService.getPostsByTagName("tag", PageRequest.of(0, 10))).thenReturn(new PageImpl<>(List.of(postSummaryDTO)));
 
-        ResponseEntity<List<PostSummaryDTO>> response = postController.getPostsByTag("tag");
+        ResponseEntity<Page<PostSummaryDTO>> response = postController.getPostsByTag("tag", 0, 10);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals("Test Title", response.getBody().get(0).getTitle());
+        assertEquals("Test Title", response.getBody().getContent().get(0).getTitle());
     }
 }

--- a/src/test/java/com/tamerm/blog_app/unit/controller/PostControllerTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/controller/PostControllerTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -142,5 +143,31 @@ class PostControllerTest {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("Test Title", response.getBody().getContent().get(0).getTitle());
+    }
+
+    /**
+     * Tests that full-text search returns matching posts.
+     */
+    @Test
+    void searchPosts_ShouldReturnMatchingPosts() {
+        Mockito.when(postService.searchPosts("test", PageRequest.of(0, 10))).thenReturn(new PageImpl<>(List.of(postSummaryDTO)));
+
+        ResponseEntity<Page<PostSummaryDTO>> response = postController.searchPosts("test", 0, 10);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Test Title", response.getBody().getContent().get(0).getTitle());
+    }
+
+    /**
+     * Tests that an empty page is returned when no posts match the search query.
+     */
+    @Test
+    void searchPosts_ShouldReturnEmptyPage_WhenNoMatches() {
+        Mockito.when(postService.searchPosts("nomatch", PageRequest.of(0, 10))).thenReturn(Page.empty());
+
+        ResponseEntity<Page<PostSummaryDTO>> response = postController.searchPosts("nomatch", 0, 10);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().isEmpty());
     }
 }

--- a/src/test/java/com/tamerm/blog_app/unit/repository/PostRepositoryTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/repository/PostRepositoryTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -117,11 +120,11 @@ class PostRepositoryTest {
         post.setUser(user);
         postRepository.save(post);
 
-        List<Post> posts = postRepository.findAllByTags_Name("tag1");
+        Page<Post> posts = postRepository.findAllByTags_Name("tag1", PageRequest.of(0, 10));
 
         assertNotNull(posts);
         assertFalse(posts.isEmpty());
-        assertEquals("Test Post", posts.get(0).getTitle());
+        assertEquals("Test Post", posts.getContent().get(0).getTitle());
     }
 
     /**
@@ -129,7 +132,7 @@ class PostRepositoryTest {
      */
     @Test
     void findAllByTags_Name_ShouldReturnEmptyList_WhenNoPostsWithTag() {
-        List<Post> posts = postRepository.findAllByTags_Name("nonexistentTag");
+        Page<Post> posts = postRepository.findAllByTags_Name("nonexistentTag", PageRequest.of(0, 10));
 
         assertNotNull(posts);
         assertTrue(posts.isEmpty());

--- a/src/test/java/com/tamerm/blog_app/unit/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/service/impl/PostServiceImplTest.java
@@ -22,6 +22,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeMap;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -133,14 +138,15 @@ class PostServiceImplTest {
      */
     @Test
     void getAllPosts_ShouldReturnAllPosts() {
-        when(postRepository.findAll()).thenReturn(List.of(post));
+        Pageable pageable = PageRequest.of(0, 10);
+        when(postRepository.findAll(pageable)).thenReturn(new PageImpl<>(List.of(post)));
 
-        List<PostSummaryDTO> result = postService.getAllPosts();
+        Page<PostSummaryDTO> result = postService.getAllPosts(pageable);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
-        assertEquals("Test Title", result.get(0).getTitle());
-        verify(postRepository, times(1)).findAll();
+        assertEquals("Test Title", result.getContent().get(0).getTitle());
+        verify(postRepository, times(1)).findAll(pageable);
     }
 
     /**
@@ -226,24 +232,26 @@ class PostServiceImplTest {
      */
     @Test
     void getPostsByTagName_ShouldReturnPosts() {
-        when(postRepository.findAllByTags_Name("tag")).thenReturn(List.of(post));
+        Pageable pageable = PageRequest.of(0, 10);
+        when(postRepository.findAllByTags_Name("tag", pageable)).thenReturn(new PageImpl<>(List.of(post)));
 
-        List<PostSummaryDTO> result = postService.getPostsByTagName("tag");
+        Page<PostSummaryDTO> result = postService.getPostsByTagName("tag", pageable);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
-        assertEquals("Test Title", result.get(0).getTitle());
-        verify(postRepository, times(1)).findAllByTags_Name("tag");
+        assertEquals("Test Title", result.getContent().get(0).getTitle());
+        verify(postRepository, times(1)).findAllByTags_Name("tag", pageable);
     }
 
     /**
-     * Tests that an empty list is returned when no posts with the specified tag name exist.
+     * Tests that an empty page is returned when no posts with the specified tag name exist.
      */
     @Test
-    void getPostsByTagName_ShouldReturnEmptyList_WhenNoPostsWithTag() {
-        when(postRepository.findAllByTags_Name("tag")).thenReturn(Collections.emptyList());
+    void getPostsByTagName_ShouldReturnEmptyPage_WhenNoPostsWithTag() {
+        Pageable pageable = PageRequest.of(0, 10);
+        when(postRepository.findAllByTags_Name("tag", pageable)).thenReturn(Page.empty());
 
-        List<PostSummaryDTO> result = postService.getPostsByTagName("tag");
+        Page<PostSummaryDTO> result = postService.getPostsByTagName("tag", pageable);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());

--- a/src/test/java/com/tamerm/blog_app/unit/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/service/impl/PostServiceImplTest.java
@@ -13,6 +13,7 @@ import com.tamerm.blog_app.request.CreatePostRequest;
 import com.tamerm.blog_app.request.UpdatePostRequest;
 import com.tamerm.blog_app.service.TagService;
 import com.tamerm.blog_app.service.impl.PostServiceImpl;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,6 +55,9 @@ class PostServiceImplTest {
     @Mock
     private TypeMap<UpdatePostRequest, Post> typeMap;
 
+    @Mock
+    private EntityManager entityManager;
+
     @InjectMocks
     private PostServiceImpl postService;
 
@@ -71,8 +75,8 @@ class PostServiceImplTest {
                 .password("password")
                 .displayName("Test user")
                 .build();
-        post = new Post(1L, "Test Title", "Test Text", user, Collections.emptySet());
-        postDTO = new PostDTO(1L, "Test Title", "Test Text", Collections.emptySet());
+        post = new Post(1L, "Test Title", "Test Text", user, Collections.emptySet(), new java.util.ArrayList<>());
+        postDTO = new PostDTO(1L, "Test Title", "Test Text", Collections.emptySet(), null);
         createPostRequest = new CreatePostRequest("Test Title", "Test Text", Collections.emptyList());
         updatePostRequest = new UpdatePostRequest("Updated Title", "Updated Text", Collections.emptyList());
     }

--- a/src/test/java/com/tamerm/blog_app/unit/util/mapper/ModelMapperTest.java
+++ b/src/test/java/com/tamerm/blog_app/unit/util/mapper/ModelMapperTest.java
@@ -37,7 +37,7 @@ class ModelMapperTest {
      */
     @Test
     void testMapPostToPostDTO() {
-        Post post = new Post(1L, "Test Title", "Test Content", user, new HashSet<>());
+        Post post = new Post(1L, "Test Title", "Test Content", user, new HashSet<>(), new java.util.ArrayList<>());
 
         PostDTO postDTO = modelMapper.map(post, PostDTO.class);
 
@@ -52,7 +52,7 @@ class ModelMapperTest {
      */
     @Test
     void testMapPostDTOToPost() {
-        PostDTO postDTO = new PostDTO(1L, "Test Title", "Test Content", new HashSet<>());
+        PostDTO postDTO = new PostDTO(1L, "Test Title", "Test Content", new HashSet<>(), null);
 
         Post post = modelMapper.map(postDTO, Post.class);
         post.setUser(user); // Set the user manually
@@ -68,7 +68,7 @@ class ModelMapperTest {
      */
     @Test
     void testMapPostToPostSummaryDTO() {
-        Post post = new Post(1L, "Test Title", "Test Content", user, new HashSet<>());
+        Post post = new Post(1L, "Test Title", "Test Content", user, new HashSet<>(), new java.util.ArrayList<>());
 
         PostSummaryDTO postSummaryDTO = modelMapper.map(post, PostSummaryDTO.class);
 
@@ -95,7 +95,7 @@ class ModelMapperTest {
      */
     @Test
     void testMapPostWithNullValues() {
-        Post post = new Post(1L, null, null, user, null);
+        Post post = new Post(1L, null, null, user, null, null);
 
         PostDTO postDTO = modelMapper.map(post, PostDTO.class);
 


### PR DESCRIPTION
## What's in this PR

All v0.3.0 requirements implemented:

- **Pagination** — `GET /posts` and `GET /posts/byTag/{tag}` now accept `page` and `size` query params and return `Page<PostSummaryDTO>`
- **Full-text search** — `GET /posts/search?q=` searches across post title, text and tags using Hibernate Search + Lucene backend
- **SonarQube** — JaCoCo coverage reporting + sonar-maven-plugin integration, SonarQube service added to docker-compose
- **Media** — `POST /posts/{id}/media` for image/video uploads; images are stored in ORIGINAL, LARGE (1280px), MEDIUM (640px) and SMALL (320px) variants using Thumbnailator

## Test plan
- 53 unit tests passing